### PR TITLE
ExAws can be used as an AWS client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `cloud_watch` and `aws` to your list of dependencies in `mix.exs`:
 
   ```elixir
   def deps do
-    [{:cloud_watch, "~> 0.2.7"},
+    [{:cloud_watch, "~> 0.2.8"},
     {:aws, "~> 0.5.0"}]
   end
   ```
@@ -58,7 +58,7 @@ Replace `aws` with `ex-aws` in your list of dependencies in `mix.exs`:
 
   ```elixir
   def deps do
-    [{:cloud_watch, "~> 0.2.7"},
+    [{:cloud_watch, "~> 0.2.8"},
     {:ex_aws, "~> 2.0"}]
   end
   ```

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ CloudWatch.
 
 ## Installation
 
-Add `cloud_watch` to your list of dependencies in `mix.exs`:
+Add `cloud_watch` and `aws` to your list of dependencies in `mix.exs`:
 
   ```elixir
   def deps do
-    [{:cloud_watch, "~> 0.2.6"}]
+    [{:cloud_watch, "~> 0.2.7"},
+    {:aws, "~> 0.5.0"}]
   end
   ```
 
@@ -49,3 +50,24 @@ The `endpoint` may be omitted from the configuration and will default to
 `amazonaws.com`. The `max_buffer_size` controls when `cloud_watch` will flush
 the buffer in bytes. You may specify anything up to a maximum of 1,048,576
 bytes. If omitted, it will default to 10,485 bytes.
+
+## Alternative AWS client library: ExAws
+
+Default installation instructions assume that the [AWS](https://github.com/jkakar/aws-elixir) Elixir library will be used. If you have to (or prefer to) use [ExAws](https://github.com/ex-aws/ex_aws) instead, solution is really simple:
+Replace `aws` with `ex-aws` in your list of dependencies in `mix.exs`:
+
+  ```elixir
+  def deps do
+    [{:cloud_watch, "~> 0.2.7"},
+    {:ex_aws, "~> 2.0"}]
+  end
+  ```
+
+CloudWatch switches to ExAws automagically based on its presence at compile time. Just make sure that `aws` is not added as a dependency of another application in an umbrella project.
+
+
+Note that `ExAws` resolves AWS credentials through its own configuration. As a consequence, following keys in CloudWatch configuration are not used:
+- `access_key_id`
+- `secret_access_key`
+- `region`
+- `endpoint`

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Add `cloud_watch` and `aws` to your list of dependencies in `mix.exs`:
 
   ```elixir
   def deps do
-    [{:cloud_watch, "~> 0.2.8"},
-    {:aws, "~> 0.5.0"}]
+    [{:cloud_watch, "~> 0.3.0"},
+     {:aws, "~> 0.5.0"}]
   end
   ```
 

--- a/lib/cloud_watch.ex
+++ b/lib/cloud_watch.ex
@@ -7,6 +7,7 @@ defmodule CloudWatch do
   @default_max_timeout 60_000
 
   alias CloudWatch.InputLogEvent
+  alias CloudWatch.AwsProxy
 
   def init(_) do
     state = configure(Application.get_env(:logger, CloudWatch, []))
@@ -61,18 +62,19 @@ defmodule CloudWatch do
 
   defp configure(opts) do
     opts = Keyword.merge(Application.get_env(:logger, CloudWatch, []), opts)
-    access_key_id = Keyword.get(opts, :access_key_id)
-    endpoint = Keyword.get(opts, :endpoint, @default_endpoint)
     format = Logger.Formatter.compile(Keyword.get(opts, :format, @default_format))
     level = Keyword.get(opts, :level, @default_level)
     log_group_name = Keyword.get(opts, :log_group_name)
     log_stream_name = Keyword.get(opts, :log_stream_name)
     max_buffer_size = Keyword.get(opts, :max_buffer_size, @default_max_buffer_size)
     max_timeout = Keyword.get(opts, :max_timeout, @default_max_timeout)
+
+    # AWS configuration, only if needed by the AWS library
     region = Keyword.get(opts, :region)
+    access_key_id = Keyword.get(opts, :access_key_id)
+    endpoint = Keyword.get(opts, :endpoint, @default_endpoint)
     secret_access_key = Keyword.get(opts, :secret_access_key)
-    client = %AWS.Client{access_key_id: access_key_id, secret_access_key: secret_access_key, region: region,
-      endpoint: endpoint}
+    client = AwsProxy.client(access_key_id, secret_access_key, region, endpoint)
     %{buffer: [], buffer_size: 0, client: client, format: format, level: level, log_group_name: log_group_name,
       log_stream_name: log_stream_name, max_buffer_size: max_buffer_size, max_timeout: max_timeout,
       sequence_token: nil, flushed_at: nil}
@@ -88,7 +90,7 @@ defmodule CloudWatch do
   defp flush(%{buffer: []} = state, _opts), do: {:ok, state}  
 
   defp flush(state, opts) do
-    case AWS.Logs.put_log_events(state.client, %{logEvents: Enum.sort_by(state.buffer, &(&1.timestamp)),
+    case AwsProxy.put_log_events(state.client, %{logEvents: Enum.sort_by(state.buffer, &(&1.timestamp)),
       logGroupName: state.log_group_name, logStreamName: state.log_stream_name, sequenceToken: state.sequence_token}) do
         {:ok, %{"nextSequenceToken" => next_sequence_token}, _} ->
           {:ok, Map.merge(state, %{buffer: [], buffer_size: 0, sequence_token: next_sequence_token})}
@@ -101,12 +103,12 @@ defmodule CloudWatch do
           |> Map.put(:sequence_token, next_sequence_token)
           |> flush(opts)
         {:error, {"ResourceNotFoundException", "The specified log group does not exist."}} ->
-          AWS.Logs.create_log_group(state.client, %{logGroupName: state.log_group_name})
-          AWS.Logs.create_log_stream(state.client, %{logGroupName: state.log_group_name,
+          AwsProxy.create_log_group(state.client, %{logGroupName: state.log_group_name})
+          AwsProxy.create_log_stream(state.client, %{logGroupName: state.log_group_name,
             logStreamName: state.log_stream_name})
           flush(state, opts)
         {:error, {"ResourceNotFoundException", "The specified log stream does not exist."}} ->
-          AWS.Logs.create_log_stream(state.client, %{logGroupName: state.log_group_name,
+          AwsProxy.create_log_stream(state.client, %{logGroupName: state.log_group_name,
             logStreamName: state.log_stream_name})
           flush(state, opts)
         {:error, %HTTPoison.Error{id: nil, reason: reason}} when reason in [:closed, :connect_timeout, :timeout] ->

--- a/lib/cloud_watch/aws_proxy.ex
+++ b/lib/cloud_watch/aws_proxy.ex
@@ -1,0 +1,89 @@
+defmodule CloudWatch.AwsProxy do
+  @moduledoc """
+    Calls to AWS CloudWatch Logs using one of alternative Elixir client libraries.
+
+    Add either :aws or :ex_aws as a dependency, and correct proxy methods will be chosen.
+  """
+
+  cond do
+    Code.ensure_loaded?(AWS) ->
+      # AWS CloudWatch Logs implemented using aws-elixir
+      # See https://github.com/jkakar/aws-elixir
+      #
+      # AWS credentials are configured in CloudWatch
+      def client(access_key_id, secret_access_key, region, endpoint) do
+        %AWS.Client{access_key_id: access_key_id, secret_access_key: secret_access_key, region: region, endpoint: endpoint}
+      end
+
+      def create_log_group(client, input) do
+        AWS.Logs.create_log_group(client, input)
+      end
+
+      def create_log_stream(client, input) do
+        AWS.Logs.create_log_stream(client, input)
+      end
+
+      def put_log_events(client, input) do
+        AWS.Logs.put_log_events(client, input)
+      end
+
+    Code.ensure_loaded?(ExAws) ->
+      # AWS CloudWatch Logs implemented using ex_aws
+      #  See https://github.com/ex-aws/ex_aws
+      #
+      # AWS credentials are configured in ExAws (shared with other AWS clients)
+      def client(_access_key_id, _secret_access_key, _region, _endpoint) do
+        %{} # nothing, we rely on config :ex_aws
+      end
+
+      def create_log_group(_client, input) do
+        request("CreateLogGroup", input)
+      end
+
+      def create_log_stream(_client, input) do
+        request("CreateLogStream", input)
+      end
+
+      def put_log_events(_client, input) do
+        request("PutLogEvents", input)
+      end
+
+      defp request(action, data) do
+        op = %ExAws.Operation.JSON{
+          http_method: :post,
+          service: :logs,
+          headers: [
+            {"x-amz-target", "Logs_20140328.#{action}"},
+            {"content-type", "application/x-amz-json-1.1"}
+          ],
+          data: data
+        }
+        case ExAws.request(op) do
+          #      {:ok, {:ok, 200, response_body}} ->
+          {:ok, response_body} ->
+            {:ok, response_body, response_body}
+          {:error, {:http_error, _error_code, %{"__type" => type, "message" => message}}} ->
+            {:error, {type, message}}
+        end
+      end
+
+    true ->
+      # No AWS library found
+      def client(_access_key_id, _secret_access_key, _region, _endpoint) do
+        raise ":aws or :ex_aws must be added as a dependency to use this module"
+      end
+
+      def create_log_group(_client, _input) do
+        raise ":aws or :ex_aws must be added as a dependency to use this module"
+      end
+
+      def create_log_stream(_client, _input) do
+        raise ":aws or :ex_aws must be added as a dependency to use this module"
+      end
+
+      def put_log_events(_client, _input) do
+        raise ":aws or :ex_aws must be added as a dependency to use this module"
+      end
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule CloudWatch.Mixfile do
 
   def project do
     [app: :cloud_watch,
-     version: "0.2.7",
+     version: "0.2.8",
      elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -36,6 +36,7 @@ defmodule CloudWatch.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:aws, "~> 0.5.0", optional: true},
+     {:httpoison, "~> 0.11.1"},
      {:credo, "~> 0.4.13", only: :dev},
      {:mock, "~> 0.2.0", only: :test},
      {:ex_doc, ">= 0.0.0", only: :dev}]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule CloudWatch.Mixfile do
 
   def project do
     [app: :cloud_watch,
-     version: "0.2.8",
+     version: "0.3.0",
      elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule CloudWatch.Mixfile do
 
   def project do
     [app: :cloud_watch,
-     version: "0.2.6",
+     version: "0.2.7",
      elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -17,7 +17,7 @@ defmodule CloudWatch.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:aws, :logger]]
+    [applications: [:logger]]
   end
 
   # This makes sure your factory and any other modules in test/support are compiled
@@ -35,7 +35,7 @@ defmodule CloudWatch.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:aws, "~> 0.5.0"},
+    [{:aws, "~> 0.5.0", optional: true},
      {:credo, "~> 0.4.13", only: :dev},
      {:mock, "~> 0.2.0", only: :test},
      {:ex_doc, ">= 0.0.0", only: :dev}]


### PR DESCRIPTION
CloudWatch logger is using AWS client https://github.com/jkakar/aws-elixir.
This pull request allows switching to an alternative ExAws client, https://github.com/ex-aws/ex_aws.  Simply add your favourite AWS library (`:aws` or `:ex_aws`) as a dependency!