### PR TITLE
Add clause in `flush/2` to handle ExAws errors.

### DIFF
--- a/lib/cloud_watch.ex
+++ b/lib/cloud_watch.ex
@@ -114,6 +114,8 @@ defmodule CloudWatch do
         {:error, %HTTPoison.Error{id: nil, reason: reason}} when reason in [:closed, :connect_timeout, :timeout] ->
           state
           |> flush(opts)
+        {:error, {type, _message}} when type in [:closed, :connect_timeout, :timeout] ->
+          flush(state, opts)
     end
   end
 end


### PR DESCRIPTION
This adds a clause in `flush/2` to handle errors passed up from the
AwsProxy module when ExAws is being used instead of AWS.

Fixes #7