### PR TITLE
Handle ExAws errors passed up through AwsProxy

### DIFF
--- a/lib/cloud_watch.ex
+++ b/lib/cloud_watch.ex
@@ -114,6 +114,8 @@ defmodule CloudWatch do
         {:error, %HTTPoison.Error{id: nil, reason: reason}} when reason in [:closed, :connect_timeout, :timeout] ->
           state
           |> flush(opts)
+        {:error, {type, _message}} when type in [:closed, :connect_timeout, :timeout] ->
+          flush(state, opts)
     end
   end
 end

--- a/lib/cloud_watch/aws_proxy.ex
+++ b/lib/cloud_watch/aws_proxy.ex
@@ -64,6 +64,8 @@ defmodule CloudWatch.AwsProxy do
             {:ok, response_body, response_body}
           {:error, {:http_error, _error_code, %{"__type" => type, "message" => message}}} ->
             {:error, {type, message}}
+          {:error, {type, message}} ->
+            {:error, {type, message}}
         end
       end
 


### PR DESCRIPTION
This one actually fixed the issue my application was experiencing in production, as compared to the closed PR I made earlier.