### PR TITLE
Added dynamic log stream names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `cloud_watch` and `aws` to your list of dependencies in `mix.exs`:
 
   ```elixir
   def deps do
-    [{:cloud_watch, "~> 0.3.1"},
+    [{:cloud_watch, "~> 0.3.2"},
      {:aws, "~> 0.5.0"}]
   end
   ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ The `endpoint` may be omitted from the configuration and will default to
 the buffer in bytes. You may specify anything up to a maximum of 1,048,576
 bytes. If omitted, it will default to 10,485 bytes.
 
+### Dynamic log stream names
+Some applications need more flexibility in `log_stream_name`, incl. ability to change the name dynamically (e.g. every day or every hour).\
+If you configure log_stream_name as a tuple `{module, function, args}` (MFA), then the function will be invoked and its return value used as the stream name.
+
+Similar configuration can be used for `log_group_name` as well. \
+For example:
+  ```elixir
+  config :logger, CloudWatch,
+    log_group_name: {MyDynamicNaming, :append_node_name, ["/aws/ec2/my-app-logs/"]},
+    log_stream_name: {MyDynamicNaming, :get_log_stream_name_change_every_day, []}
+
+  defmodule MyDynamicNaming do
+    def append_node_name(value), do: "#{value}#{node()}"
+    def get_log_stream_name_change_every_day(), do: "#{Date.utc_today()}/my-log-stream"
+  end
+```
+
 ## Alternative AWS client library: ExAws
 
 Default installation instructions assume that the [AWS](https://github.com/jkakar/aws-elixir) Elixir library will be used. If you have to (or prefer to) use [ExAws](https://github.com/ex-aws/ex_aws) instead, solution is really simple:

--- a/lib/cloud_watch.ex
+++ b/lib/cloud_watch.ex
@@ -5,6 +5,7 @@ defmodule CloudWatch do
   @default_level :info
   @default_max_buffer_size 10_485
   @default_max_timeout 60_000
+  @max_buffer_size 10_000
 
   alias CloudWatch.InputLogEvent
   alias CloudWatch.AwsProxy
@@ -27,19 +28,13 @@ defmodule CloudWatch do
     case Logger.compare_levels(level, state.level) do
       :lt -> {:ok, state}
       _ ->
-        %{buffer: buffer, buffer_size: buffer_size} = state
-        message = state.format
-        |> Logger.Formatter.format(level, msg, ts, md)
-        |> IO.chardata_to_string
-        buffer = List.insert_at(buffer, -1, %InputLogEvent{message: message, timestamp: ts})
-        state
-        |> Map.merge(%{buffer: buffer, buffer_size: buffer_size + byte_size(message) + 26})
-        |> flush()
+        state = add_message(state, level, msg, ts, md)
+        flush(state)
     end
   end
 
   def handle_event(:flush, state) do
-    {:ok, Map.merge(state, %{buffer: [], buffer_size: 0})}
+    {:ok, purge_buffer(state)}
   end
 
   def handle_info(:flush, state) do
@@ -75,19 +70,43 @@ defmodule CloudWatch do
     endpoint = Keyword.get(opts, :endpoint, @default_endpoint)
     secret_access_key = Keyword.get(opts, :secret_access_key)
     client = AwsProxy.client(access_key_id, secret_access_key, region, endpoint)
-    %{buffer: [], buffer_size: 0, client: client, format: format, level: level, log_group_name: log_group_name,
-      log_stream_name: log_stream_name, max_buffer_size: max_buffer_size, max_timeout: max_timeout,
-      sequence_token: nil, flushed_at: nil}
+    %{
+      buffer: [],
+      buffer_length: 0, # for a large list, this is less expensive than length(buffer)
+      buffer_size: 0,
+      client: client,
+      format: format,
+      level: level,
+      log_group_name: log_group_name,
+      log_stream_name: log_stream_name,
+      max_buffer_size: max_buffer_size,
+      max_timeout: max_timeout,
+      sequence_token: nil,
+      flushed_at: nil
+    }
+  end
+
+  defp purge_buffer(state) do
+    %{state | buffer: [], buffer_length: 0, buffer_size: 0}
+  end
+
+  defp add_message(%{buffer: buffer, buffer_length: buffer_length, buffer_size: buffer_size} = state, level, msg, ts, md) do
+    message = state.format
+              |> Logger.Formatter.format(level, msg, ts, md)
+              |> IO.chardata_to_string
+    #buffer = List.insert_at(buffer, -1, %InputLogEvent{message: message, timestamp: ts}) # performance impact of adding at the end?
+    buffer = [%InputLogEvent{message: message, timestamp: ts} | buffer] # buffer order is not relevant, we'll reverse or sort later if needed
+    %{state | buffer: buffer, buffer_length: buffer_length + 1, buffer_size: buffer_size + byte_size(message) + 26}
   end
 
   defp flush(_state, _opts \\ [force: false])
 
-  defp flush(%{buffer: buffer, buffer_size: buffer_size, max_buffer_size: max_buffer_size} = state, [force: false])
-    when buffer_size < max_buffer_size and length(buffer) < 10_000 do
+  defp flush(%{buffer_length: buffer_length, buffer_size: buffer_size, max_buffer_size: max_buffer_size} = state, [force: false])
+    when buffer_size < max_buffer_size and buffer_length < @max_buffer_size do
       {:ok, state}
   end
-  
-  defp flush(%{buffer: []} = state, _opts), do: {:ok, state}  
+
+  defp flush(%{buffer: []} = state, _opts), do: {:ok, state}
 
   defp flush(state, opts) do
     # Log names could change between calls, but has to remain stable inside the method `do_flush/4`
@@ -96,34 +115,41 @@ defmodule CloudWatch do
     do_flush(state, opts, log_group_name, log_stream_name)
   end
 
-  defp do_flush(state, opts, log_group_name, log_stream_name) do
-    case AwsProxy.put_log_events(state.client, %{logEvents: Enum.sort_by(state.buffer, &(&1.timestamp)),
-      logGroupName: log_group_name, logStreamName: log_stream_name, sequenceToken: state.sequence_token}) do
-        {:ok, %{"nextSequenceToken" => next_sequence_token}, _} ->
-          {:ok, Map.merge(state, %{buffer: [], buffer_size: 0, sequence_token: next_sequence_token})}
-        {:error, {"DataAlreadyAcceptedException", "The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: " <> next_sequence_token}} ->
-          state
-          |> Map.put(:sequence_token, next_sequence_token)
-          |> do_flush(opts, log_group_name, log_stream_name)
-        {:error, {"InvalidSequenceTokenException", "The given sequenceToken is invalid. The next expected sequenceToken is: " <> next_sequence_token}} ->
-          state
-          |> Map.put(:sequence_token, next_sequence_token)
-          |> do_flush(opts, log_group_name, log_stream_name)
-        {:error, {"ResourceNotFoundException", "The specified log group does not exist."}} ->
-          AwsProxy.create_log_group(state.client, %{logGroupName: log_group_name})
-          AwsProxy.create_log_stream(state.client, %{logGroupName: log_group_name, logStreamName: log_stream_name})
-          state
-          |> Map.put(:sequence_token, nil)
-          |> do_flush(opts, log_group_name, log_stream_name)
-        {:error, {"ResourceNotFoundException", "The specified log stream does not exist."}} ->
-          AwsProxy.create_log_stream(state.client, %{logGroupName: log_group_name, logStreamName: log_stream_name})
-          state
-          |> Map.put(:sequence_token, nil)
-          |> do_flush(opts, log_group_name, log_stream_name)
-        {:error, %HTTPoison.Error{id: nil, reason: reason}} when reason in [:closed, :connect_timeout, :timeout] ->
-          do_flush(state, opts, log_group_name, log_stream_name)
-        {:error, {type, _message}} when type in [:closed, :connect_timeout, :timeout] ->
-          do_flush(state, opts, log_group_name, log_stream_name)
+  defp do_flush(%{buffer: buffer} = state, opts, log_group_name, log_stream_name) do
+    events = %{logEvents: Enum.sort_by(buffer, &(&1.timestamp)),
+        logGroupName: log_group_name, logStreamName: log_stream_name, sequenceToken: state.sequence_token}
+    case AwsProxy.put_log_events(state.client, events) do
+      {:ok, %{"nextSequenceToken" => next_sequence_token}, _} ->
+        {:ok, state |> purge_buffer() |> Map.put(:sequence_token, next_sequence_token)}
+      {:error, {"DataAlreadyAcceptedException", "The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: " <> next_sequence_token}} ->
+        state
+        |> Map.put(:sequence_token, next_sequence_token)
+        |> do_flush(opts, log_group_name, log_stream_name)
+      {:error, {"InvalidSequenceTokenException", "The given sequenceToken is invalid. The next expected sequenceToken is: " <> next_sequence_token}} ->
+        state
+        |> Map.put(:sequence_token, next_sequence_token)
+        |> do_flush(opts, log_group_name, log_stream_name)
+      {:error, {"ResourceNotFoundException", "The specified log group does not exist."}} ->
+        {:ok, _, _} = AwsProxy.create_log_group(state.client, %{logGroupName: log_group_name})
+        {:ok, _, _} = AwsProxy.create_log_stream(
+          state.client,
+          %{logGroupName: log_group_name, logStreamName: log_stream_name}
+        )
+        state
+        |> Map.put(:sequence_token, nil)
+        |> do_flush(opts, log_group_name, log_stream_name)
+      {:error, {"ResourceNotFoundException", "The specified log stream does not exist."}} ->
+        {:ok, _, _} = AwsProxy.create_log_stream(
+          state.client,
+          %{logGroupName: log_group_name, logStreamName: log_stream_name}
+        )
+        state
+        |> Map.put(:sequence_token, nil)
+        |> do_flush(opts, log_group_name, log_stream_name)
+      {:error, %HTTPoison.Error{id: nil, reason: reason}} when reason in [:closed, :connect_timeout, :timeout] ->
+        do_flush(state, opts, log_group_name, log_stream_name)
+      {:error, {type, _message}} when type in [:closed, :connect_timeout, :timeout] ->
+        do_flush(state, opts, log_group_name, log_stream_name)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule CloudWatch.Mixfile do
 
   def project do
     [app: :cloud_watch,
-     version: "0.3.1",
+     version: "0.3.2",
      elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/log_stream_name_test.exs
+++ b/test/log_stream_name_test.exs
@@ -1,0 +1,53 @@
+defmodule LogStreamNameTest do
+  @backend CloudWatch
+  @stream_name_prefix "2018-01-01"
+  @stream_name_postfix "test1234"
+
+  alias CloudWatch.{Cycler, InputLogEvent}
+
+  import Mock
+
+  require Logger
+
+  use ExUnit.Case, async: false
+
+  setup_all do
+    {:ok, _} = Cycler.start_link
+    Logger.add_backend(@backend)
+    :ok = Logger.configure_backend(@backend, [format: "$message", level: :info, log_group_name: "testLogGroup", log_stream_name: {LogStreamNameTest, :format_name, [@stream_name_prefix, @stream_name_postfix]}, max_buffer_size: 39])
+  end
+
+  setup do
+    on_exit fn -> Logger.flush end
+    :ok
+  end
+
+  test "creates a log stream when the log stream does not exist" do
+    log_stream_name = format_name(@stream_name_prefix, @stream_name_postfix)
+    with_mock AWS.Logs, [create_log_stream: fn (_, _) -> {:ok, nil, nil} end, put_log_events: fn (_, _) -> Cycler.next_response end] do
+      Cycler.reset_responses([{:error, {"ResourceNotFoundException", "The specified log stream does not exist."}}, {:ok, %{"nextSequenceToken" => "57682394657383646473"}, nil}])
+      Logger.error("ArithmeticError")
+      :timer.sleep(100)
+      assert called(AWS.Logs.create_log_stream(:_, %{logGroupName: "testLogGroup", logStreamName: log_stream_name}))
+      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: log_stream_name, sequenceToken: :_}))
+    end
+  end
+
+  test "creates a log group and a log stream when the log group does not exist" do
+    log_stream_name = format_name(@stream_name_prefix, @stream_name_postfix)
+    with_mock AWS.Logs, [create_log_group: fn (_, _) -> {:ok, nil, nil} end, create_log_stream: fn (_, _) -> {:ok, nil, nil} end, put_log_events: fn (_, _) -> Cycler.next_response end] do
+      Cycler.reset_responses([{:error, {"ResourceNotFoundException", "The specified log group does not exist."}}, {:ok, %{"nextSequenceToken" => "5768239465"}, nil}])
+      Logger.error("ArithmeticError")
+      :timer.sleep(100)
+      assert called(AWS.Logs.create_log_group(:_, %{logGroupName: "testLogGroup"}))
+      assert called(AWS.Logs.create_log_stream(:_, %{logGroupName: "testLogGroup", logStreamName: log_stream_name}))
+      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: log_stream_name, sequenceToken: :_}))
+    end
+  end
+
+  # Calculate log stream name
+  def format_name(prefix, postfix) do
+    "#{prefix}_LOG_STREAM_NAME_#{postfix}"
+  end
+
+end


### PR DESCRIPTION
* log_stream_name can be configured as a tuple {module, function, args}.
      Before the log data is written to CloudWatch, this function is invoked and its return value is used as a log stream name
* Similar configuration can be used for log_group_name as well

Performance optimizations:
* Explicitly maintain buffer_length, as length(buffer) for large lists is expensive
* Add new messages to the head of the list, instead of the tail

Version bumped to 0.3.2