### PR TITLE
Handle metadata and metadata filtering, better handle configuration

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: elixir
 
-elixir:
-  - 1.5.1
+matrix:
+  include:
+    - elixir: 1.5.1
+      otp_release: 20.0
+    - elixir: 1.8.2
+      otp_release: 21.3
+      env: CHECK_FORMATTED=true
 
-otp_release:
-  - 20.0
+script:
+  - if [ "$CHECK_FORMATTED" = true ]; then mix format --check-formatted; fi
+  - mix test

--- a/README.md
+++ b/README.md
@@ -43,13 +43,40 @@ Configure the following example to suit your needs:
     log_group_name: "api",
     log_stream_name: "production",
     max_buffer_size: 10_485,
-    max_timeout: 60_000
+    max_timeout: 60_000,
+    metadata: [:m1, :m2],
+    metadata_filter: [module: MyModule]
+  ```
+
+Multiple `CloudWatch` backends can be specified by adding tuples in the
+format `{CloudWatch, :backend_name}`:
+
+  ```elixir
+  config :logger,
+    utc_log: true,
+    backends: [
+      :console,
+      {CloudWatch, :cloud_error},
+      {CloudWatch, :cloud_debug}
+    ]
+
+  config :logger, cloud_error,
+    level: :error
+    # other options
+
+  config :logger, cloud_debug,
+    level: :debug
+    # other options
   ```
 
 The `endpoint` may be omitted from the configuration and will default to
 `amazonaws.com`. The `max_buffer_size` controls when `cloud_watch` will flush
 the buffer in bytes. You may specify anything up to a maximum of 1,048,576
 bytes. If omitted, it will default to 10,485 bytes.
+
+The `metadata` parameter selects which metadata should be printed with the
+log message. The `metadata_filter` specifies instead metadata terms which must
+be present in order to log.
 
 ### Dynamic log stream names
 Some applications need more flexibility in `log_stream_name`, incl. ability to change the name dynamically (e.g. every day or every hour).\

--- a/lib/cloud_watch.ex
+++ b/lib/cloud_watch.ex
@@ -26,7 +26,9 @@ defmodule CloudWatch do
 
   def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
     case Logger.compare_levels(level, state.level) do
-      :lt -> {:ok, state}
+      :lt ->
+        {:ok, state}
+
       _ ->
         state = add_message(state, level, msg, ts, md)
         flush(state)
@@ -70,9 +72,11 @@ defmodule CloudWatch do
     endpoint = Keyword.get(opts, :endpoint, @default_endpoint)
     secret_access_key = Keyword.get(opts, :secret_access_key)
     client = AwsProxy.client(access_key_id, secret_access_key, region, endpoint)
+
     %{
       buffer: [],
-      buffer_length: 0, # for a large list, this is less expensive than length(buffer)
+      # for a large list, this is less expensive than length(buffer)
+      buffer_length: 0,
       buffer_size: 0,
       client: client,
       format: format,
@@ -90,20 +94,42 @@ defmodule CloudWatch do
     %{state | buffer: [], buffer_length: 0, buffer_size: 0}
   end
 
-  defp add_message(%{buffer: buffer, buffer_length: buffer_length, buffer_size: buffer_size} = state, level, msg, ts, md) do
-    message = state.format
-              |> Logger.Formatter.format(level, msg, ts, md)
-              |> IO.chardata_to_string
-    #buffer = List.insert_at(buffer, -1, %InputLogEvent{message: message, timestamp: ts}) # performance impact of adding at the end?
-    buffer = [%InputLogEvent{message: message, timestamp: ts} | buffer] # buffer order is not relevant, we'll reverse or sort later if needed
-    %{state | buffer: buffer, buffer_length: buffer_length + 1, buffer_size: buffer_size + byte_size(message) + 26}
+  defp add_message(
+         %{buffer: buffer, buffer_length: buffer_length, buffer_size: buffer_size} = state,
+         level,
+         msg,
+         ts,
+         md
+       ) do
+    message =
+      state.format
+      |> Logger.Formatter.format(level, msg, ts, md)
+      |> IO.chardata_to_string()
+
+    # buffer = List.insert_at(buffer, -1, %InputLogEvent{message: message, timestamp: ts}) # performance impact of adding at the end?
+    # buffer order is not relevant, we'll reverse or sort later if needed
+    buffer = [%InputLogEvent{message: message, timestamp: ts} | buffer]
+
+    %{
+      state
+      | buffer: buffer,
+        buffer_length: buffer_length + 1,
+        buffer_size: buffer_size + byte_size(message) + 26
+    }
   end
 
   defp flush(_state, _opts \\ [force: false])
 
-  defp flush(%{buffer_length: buffer_length, buffer_size: buffer_size, max_buffer_size: max_buffer_size} = state, [force: false])
-    when buffer_size < max_buffer_size and buffer_length < @max_buffer_size do
-      {:ok, state}
+  defp flush(
+         %{
+           buffer_length: buffer_length,
+           buffer_size: buffer_size,
+           max_buffer_size: max_buffer_size
+         } = state,
+         force: false
+       )
+       when buffer_size < max_buffer_size and buffer_length < @max_buffer_size do
+    {:ok, state}
   end
 
   defp flush(%{buffer: []} = state, _opts), do: {:ok, state}
@@ -116,38 +142,61 @@ defmodule CloudWatch do
   end
 
   defp do_flush(%{buffer: buffer} = state, opts, log_group_name, log_stream_name) do
-    events = %{logEvents: Enum.sort_by(buffer, &(&1.timestamp)),
-        logGroupName: log_group_name, logStreamName: log_stream_name, sequenceToken: state.sequence_token}
+    events = %{
+      logEvents: Enum.sort_by(buffer, & &1.timestamp),
+      logGroupName: log_group_name,
+      logStreamName: log_stream_name,
+      sequenceToken: state.sequence_token
+    }
+
     case AwsProxy.put_log_events(state.client, events) do
       {:ok, %{"nextSequenceToken" => next_sequence_token}, _} ->
         {:ok, state |> purge_buffer() |> Map.put(:sequence_token, next_sequence_token)}
-      {:error, {"DataAlreadyAcceptedException", "The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: " <> next_sequence_token}} ->
+
+      {:error,
+       {"DataAlreadyAcceptedException",
+        "The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: " <>
+            next_sequence_token}} ->
         state
         |> Map.put(:sequence_token, next_sequence_token)
         |> do_flush(opts, log_group_name, log_stream_name)
-      {:error, {"InvalidSequenceTokenException", "The given sequenceToken is invalid. The next expected sequenceToken is: " <> next_sequence_token}} ->
+
+      {:error,
+       {"InvalidSequenceTokenException",
+        "The given sequenceToken is invalid. The next expected sequenceToken is: " <>
+            next_sequence_token}} ->
         state
         |> Map.put(:sequence_token, next_sequence_token)
         |> do_flush(opts, log_group_name, log_stream_name)
+
       {:error, {"ResourceNotFoundException", "The specified log group does not exist."}} ->
         {:ok, _, _} = AwsProxy.create_log_group(state.client, %{logGroupName: log_group_name})
-        {:ok, _, _} = AwsProxy.create_log_stream(
-          state.client,
-          %{logGroupName: log_group_name, logStreamName: log_stream_name}
-        )
+
+        {:ok, _, _} =
+          AwsProxy.create_log_stream(
+            state.client,
+            %{logGroupName: log_group_name, logStreamName: log_stream_name}
+          )
+
         state
         |> Map.put(:sequence_token, nil)
         |> do_flush(opts, log_group_name, log_stream_name)
+
       {:error, {"ResourceNotFoundException", "The specified log stream does not exist."}} ->
-        {:ok, _, _} = AwsProxy.create_log_stream(
-          state.client,
-          %{logGroupName: log_group_name, logStreamName: log_stream_name}
-        )
+        {:ok, _, _} =
+          AwsProxy.create_log_stream(
+            state.client,
+            %{logGroupName: log_group_name, logStreamName: log_stream_name}
+          )
+
         state
         |> Map.put(:sequence_token, nil)
         |> do_flush(opts, log_group_name, log_stream_name)
-      {:error, %HTTPoison.Error{id: nil, reason: reason}} when reason in [:closed, :connect_timeout, :timeout] ->
+
+      {:error, %HTTPoison.Error{id: nil, reason: reason}}
+      when reason in [:closed, :connect_timeout, :timeout] ->
         do_flush(state, opts, log_group_name, log_stream_name)
+
       {:error, {type, _message}} when type in [:closed, :connect_timeout, :timeout] ->
         do_flush(state, opts, log_group_name, log_stream_name)
     end
@@ -157,9 +206,9 @@ defmodule CloudWatch do
   defp resolve_name({m, f, a}) do
     :erlang.apply(m, f, a)
   end
+
   # Use the name directly
   defp resolve_name(name) do
     name
   end
-
 end

--- a/lib/cloud_watch/aws_proxy.ex
+++ b/lib/cloud_watch/aws_proxy.ex
@@ -12,7 +12,12 @@ defmodule CloudWatch.AwsProxy do
       #
       # AWS credentials are configured in CloudWatch
       def client(access_key_id, secret_access_key, region, endpoint) do
-        %AWS.Client{access_key_id: access_key_id, secret_access_key: secret_access_key, region: region, endpoint: endpoint}
+        %AWS.Client{
+          access_key_id: access_key_id,
+          secret_access_key: secret_access_key,
+          region: region,
+          endpoint: endpoint
+        }
       end
 
       def create_log_group(client, input) do
@@ -33,7 +38,8 @@ defmodule CloudWatch.AwsProxy do
       #
       # AWS credentials are configured in ExAws (shared with other AWS clients)
       def client(_access_key_id, _secret_access_key, _region, _endpoint) do
-        %{} # nothing, we rely on config :ex_aws
+        # nothing, we rely on config :ex_aws
+        %{}
       end
 
       def create_log_group(_client, input) do
@@ -58,12 +64,15 @@ defmodule CloudWatch.AwsProxy do
           ],
           data: data
         }
+
         case ExAws.request(op) do
           #      {:ok, {:ok, 200, response_body}} ->
           {:ok, response_body} ->
             {:ok, response_body, response_body}
+
           {:error, {:http_error, _error_code, %{"__type" => type, "message" => message}}} ->
             {:error, {type, message}}
+
           {:error, {type, message}} ->
             {:error, {type, message}}
         end
@@ -87,5 +96,4 @@ defmodule CloudWatch.AwsProxy do
         raise ":aws or :ex_aws must be added as a dependency to use this module"
       end
   end
-
 end

--- a/lib/cloud_watch/input_log_event.ex
+++ b/lib/cloud_watch/input_log_event.ex
@@ -1,18 +1,21 @@
 defmodule CloudWatch.InputLogEvent do
-  @enforce_keys  [:message, :timestamp]
+  @enforce_keys [:message, :timestamp]
 
   defimpl Poison.Encoder do
     @epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
 
     def encode(%{message: message, timestamp: timestamp}, options) do
       {{years, months, days}, {hours, minutes, seconds, milliseconds}} = timestamp
-      timestamp = :calendar.datetime_to_gregorian_seconds({{years, months, days}, {hours, minutes, seconds}})
-      |> Kernel.-(@epoch)
-      |> Kernel.*(1000)
-      |> Kernel.+(milliseconds)
+
+      timestamp =
+        :calendar.datetime_to_gregorian_seconds({{years, months, days}, {hours, minutes, seconds}})
+        |> Kernel.-(@epoch)
+        |> Kernel.*(1000)
+        |> Kernel.+(milliseconds)
+
       %{message: message, timestamp: timestamp}
       |> Poison.Encoder.encode(options)
-      |> IO.chardata_to_string
+      |> IO.chardata_to_string()
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,15 +2,17 @@ defmodule CloudWatch.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :cloud_watch,
-     version: "0.3.2",
-     elixir: "~> 1.5",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     elixirc_paths: elixirc_paths(Mix.env),
-     description: "Amazon CloudWatch-logger backend for Elixir",
-     package: package()]
+    [
+      app: :cloud_watch,
+      version: "0.3.2",
+      elixir: "~> 1.5",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env()),
+      description: "Amazon CloudWatch-logger backend for Elixir",
+      package: package()
+    ]
   end
 
   # Configuration for the OTP application
@@ -35,17 +37,21 @@ defmodule CloudWatch.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:aws, "~> 0.5.0", optional: true},
-     {:httpoison, "~> 0.11.1"},
-     {:credo, "~> 0.4.13", only: :dev},
-     {:mock, "~> 0.3.2", only: :test},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+    [
+      {:aws, "~> 0.5.0", optional: true},
+      {:httpoison, "~> 0.11.1"},
+      {:credo, "~> 0.4.13", only: :dev},
+      {:mock, "~> 0.3.2", only: :test},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
   end
 
   defp package do
-    [name: :cloud_watch,
-     maintainers: ["Laurens Boekhorst", "Peter Menhart"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/lboekhorst/cloud_watch"}]
+    [
+      name: :cloud_watch,
+      maintainers: ["Laurens Boekhorst", "Peter Menhart"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/lboekhorst/cloud_watch"}
+    ]
   end
 end

--- a/test/cloud_watch/input_log_event_test.exs
+++ b/test/cloud_watch/input_log_event_test.exs
@@ -4,8 +4,13 @@ defmodule CloudWatch.InputLogEventTest do
   use ExUnit.Case
 
   test "encodes message and timestamp" do
-    input_log_event = %InputLogEvent{message: "ArgumentError", timestamp: {{2016, 10, 26}, {12, 8, 34, 220}}}
+    input_log_event = %InputLogEvent{
+      message: "ArgumentError",
+      timestamp: {{2016, 10, 26}, {12, 8, 34, 220}}
+    }
+
     encoded_input_log_event = Poison.Encoder.encode(input_log_event, [])
+
     assert encoded_input_log_event == "{\"timestamp\":1477483714220,\"message\":\"ArgumentError\"}"
   end
 end

--- a/test/cloud_watch_test.exs
+++ b/test/cloud_watch_test.exs
@@ -10,39 +10,89 @@ defmodule CloudWatchTest do
   use ExUnit.Case, async: false
 
   setup_all do
-    {:ok, _} = Cycler.start_link
+    {:ok, _} = Cycler.start_link()
     Logger.add_backend(@backend)
-    :ok = Logger.configure_backend(@backend, [format: "$message", level: :info, log_group_name: "testLogGroup", log_stream_name: "testLogStream", max_buffer_size: 39])
+
+    :ok =
+      Logger.configure_backend(@backend,
+        format: "$message",
+        level: :info,
+        log_group_name: "testLogGroup",
+        log_stream_name: "testLogStream",
+        max_buffer_size: 39
+      )
   end
 
   setup do
-    on_exit fn -> Logger.flush end
+    on_exit(fn -> Logger.flush() end)
     :ok
   end
 
   test "creates a log stream when the log stream does not exist" do
-    with_mock AWS.Logs, [create_log_stream: fn (_, _) -> {:ok, nil, nil} end, put_log_events: fn (_, _) -> Cycler.next_response end] do
-      Cycler.reset_responses([{:error, {"ResourceNotFoundException", "The specified log stream does not exist."}}, {:ok, %{"nextSequenceToken" => "57682394657383646473"}, nil}])
+    with_mock AWS.Logs,
+      create_log_stream: fn _, _ -> {:ok, nil, nil} end,
+      put_log_events: fn _, _ -> Cycler.next_response() end do
+      Cycler.reset_responses([
+        {:error, {"ResourceNotFoundException", "The specified log stream does not exist."}},
+        {:ok, %{"nextSequenceToken" => "57682394657383646473"}, nil}
+      ])
+
       Logger.error("ArithmeticError")
       :timer.sleep(100)
-      assert called(AWS.Logs.create_log_stream(:_, %{logGroupName: "testLogGroup", logStreamName: "testLogStream"}))
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: "testLogStream", sequenceToken: :_}))
+
+      assert called(
+               AWS.Logs.create_log_stream(:_, %{
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream"
+               })
+             )
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream",
+                 sequenceToken: :_
+               })
+             )
     end
   end
 
   test "creates a log group and a log stream when the log group does not exist" do
-    with_mock AWS.Logs, [create_log_group: fn (_, _) -> {:ok, nil, nil} end, create_log_stream: fn (_, _) -> {:ok, nil, nil} end, put_log_events: fn (_, _) -> Cycler.next_response end] do
-      Cycler.reset_responses([{:error, {"ResourceNotFoundException", "The specified log group does not exist."}}, {:ok, %{"nextSequenceToken" => "5768239465"}, nil}])
+    with_mock AWS.Logs,
+      create_log_group: fn _, _ -> {:ok, nil, nil} end,
+      create_log_stream: fn _, _ -> {:ok, nil, nil} end,
+      put_log_events: fn _, _ -> Cycler.next_response() end do
+      Cycler.reset_responses([
+        {:error, {"ResourceNotFoundException", "The specified log group does not exist."}},
+        {:ok, %{"nextSequenceToken" => "5768239465"}, nil}
+      ])
+
       Logger.error("ArithmeticError")
       :timer.sleep(100)
       assert called(AWS.Logs.create_log_group(:_, %{logGroupName: "testLogGroup"}))
-      assert called(AWS.Logs.create_log_stream(:_, %{logGroupName: "testLogGroup", logStreamName: "testLogStream"}))
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: "testLogStream", sequenceToken: :_}))
+
+      assert called(
+               AWS.Logs.create_log_stream(:_, %{
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream"
+               })
+             )
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream",
+                 sequenceToken: :_
+               })
+             )
     end
   end
 
   test "does not put log events that do not meet the log level" do
-    with_mock AWS.Logs, [put_log_events: fn (_, _) -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end] do
+    with_mock AWS.Logs,
+      put_log_events: fn _, _ -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end do
       Logger.debug("ArithmeticError")
       :timer.sleep(100)
       refute called(AWS.Logs.put_log_events(:_, :_))
@@ -50,7 +100,8 @@ defmodule CloudWatchTest do
   end
 
   test "does not put log events when the buffer size is less than the configured maximum buffer size" do
-    with_mock AWS.Logs, [put_log_events: fn (_, _) -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end] do
+    with_mock AWS.Logs,
+      put_log_events: fn _, _ -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end do
       Logger.error("RuntimeError")
       :timer.sleep(100)
       refute called(AWS.Logs.put_log_events(:_, :_))
@@ -58,36 +109,82 @@ defmodule CloudWatchTest do
   end
 
   test "puts log events that meet the log level" do
-    with_mock AWS.Logs, [put_log_events: fn (_, _) -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end] do
+    with_mock AWS.Logs,
+      put_log_events: fn _, _ -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end do
       Logger.info("ArgumentError")
       :timer.sleep(100)
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArgumentError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: "testLogStream", sequenceToken: :_}))
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArgumentError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream",
+                 sequenceToken: :_
+               })
+             )
     end
   end
 
   test "puts log events when the buffer size is greater then the configured maximum buffer size" do
-    with_mock AWS.Logs, [put_log_events: fn (_, _) -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end] do
+    with_mock AWS.Logs,
+      put_log_events: fn _, _ -> {:ok, %{"nextSequenceToken" => "5768239465"}, nil} end do
       Logger.error("ArithmeticError")
       :timer.sleep(100)
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: "testLogStream", sequenceToken: :_}))
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream",
+                 sequenceToken: :_
+               })
+             )
     end
   end
 
   test "puts log events with the next sequence token when the data has already been accepted" do
-    with_mock AWS.Logs, [put_log_events: fn (_, _) -> Cycler.next_response end] do
-      Cycler.reset_responses([{:error, {"DataAlreadyAcceptedException", "The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: 5768239465"}}, {:ok, %{"nextSequenceToken" => "3857374635"}, nil}])
+    with_mock AWS.Logs, put_log_events: fn _, _ -> Cycler.next_response() end do
+      Cycler.reset_responses([
+        {:error,
+         {"DataAlreadyAcceptedException",
+          "The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: 5768239465"}},
+        {:ok, %{"nextSequenceToken" => "3857374635"}, nil}
+      ])
+
       Logger.error("ArithmeticError")
       :timer.sleep(100)
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: "testLogStream", sequenceToken: "5768239465"}))
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream",
+                 sequenceToken: "5768239465"
+               })
+             )
     end
   end
 
   test "puts log events with the next sequence token when the sequence token was invalid" do
-    with_mock AWS.Logs, [put_log_events: fn (_, _) -> Cycler.next_response end] do
-      Cycler.reset_responses([{:error, {"InvalidSequenceTokenException", "The given sequenceToken is invalid. The next expected sequenceToken is: 5768239463"}}, {:ok, %{"nextSequenceToken" => "3857354916"}, nil}])
+    with_mock AWS.Logs, put_log_events: fn _, _ -> Cycler.next_response() end do
+      Cycler.reset_responses([
+        {:error,
+         {"InvalidSequenceTokenException",
+          "The given sequenceToken is invalid. The next expected sequenceToken is: 5768239463"}},
+        {:ok, %{"nextSequenceToken" => "3857354916"}, nil}
+      ])
+
       Logger.error("ArithmeticError")
       :timer.sleep(100)
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: "testLogStream", sequenceToken: "5768239463"}))
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: "testLogStream",
+                 sequenceToken: "5768239463"
+               })
+             )
     end
   end
 end

--- a/test/log_stream_name_test.exs
+++ b/test/log_stream_name_test.exs
@@ -12,36 +12,87 @@ defmodule LogStreamNameTest do
   use ExUnit.Case, async: false
 
   setup_all do
-    {:ok, _} = Cycler.start_link
+    {:ok, _} = Cycler.start_link()
     Logger.add_backend(@backend)
-    :ok = Logger.configure_backend(@backend, [format: "$message", level: :info, log_group_name: "testLogGroup", log_stream_name: {LogStreamNameTest, :format_name, [@stream_name_prefix, @stream_name_postfix]}, max_buffer_size: 39])
+
+    :ok =
+      Logger.configure_backend(@backend,
+        format: "$message",
+        level: :info,
+        log_group_name: "testLogGroup",
+        log_stream_name: {LogStreamNameTest, :format_name, [@stream_name_prefix, @stream_name_postfix]},
+        max_buffer_size: 39
+      )
   end
 
   setup do
-    on_exit fn -> Logger.flush end
+    on_exit(fn -> Logger.flush() end)
     :ok
   end
 
   test "creates a log stream when the log stream does not exist" do
     log_stream_name = format_name(@stream_name_prefix, @stream_name_postfix)
-    with_mock AWS.Logs, [create_log_stream: fn (_, _) -> {:ok, nil, nil} end, put_log_events: fn (_, _) -> Cycler.next_response end] do
-      Cycler.reset_responses([{:error, {"ResourceNotFoundException", "The specified log stream does not exist."}}, {:ok, %{"nextSequenceToken" => "57682394657383646473"}, nil}])
+
+    with_mock AWS.Logs,
+      create_log_stream: fn _, _ -> {:ok, nil, nil} end,
+      put_log_events: fn _, _ -> Cycler.next_response() end do
+      Cycler.reset_responses([
+        {:error, {"ResourceNotFoundException", "The specified log stream does not exist."}},
+        {:ok, %{"nextSequenceToken" => "57682394657383646473"}, nil}
+      ])
+
       Logger.error("ArithmeticError")
       :timer.sleep(100)
-      assert called(AWS.Logs.create_log_stream(:_, %{logGroupName: "testLogGroup", logStreamName: log_stream_name}))
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: log_stream_name, sequenceToken: :_}))
+
+      assert called(
+               AWS.Logs.create_log_stream(:_, %{
+                 logGroupName: "testLogGroup",
+                 logStreamName: log_stream_name
+               })
+             )
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: log_stream_name,
+                 sequenceToken: :_
+               })
+             )
     end
   end
 
   test "creates a log group and a log stream when the log group does not exist" do
     log_stream_name = format_name(@stream_name_prefix, @stream_name_postfix)
-    with_mock AWS.Logs, [create_log_group: fn (_, _) -> {:ok, nil, nil} end, create_log_stream: fn (_, _) -> {:ok, nil, nil} end, put_log_events: fn (_, _) -> Cycler.next_response end] do
-      Cycler.reset_responses([{:error, {"ResourceNotFoundException", "The specified log group does not exist."}}, {:ok, %{"nextSequenceToken" => "5768239465"}, nil}])
+
+    with_mock AWS.Logs,
+      create_log_group: fn _, _ -> {:ok, nil, nil} end,
+      create_log_stream: fn _, _ -> {:ok, nil, nil} end,
+      put_log_events: fn _, _ -> Cycler.next_response() end do
+      Cycler.reset_responses([
+        {:error, {"ResourceNotFoundException", "The specified log group does not exist."}},
+        {:ok, %{"nextSequenceToken" => "5768239465"}, nil}
+      ])
+
       Logger.error("ArithmeticError")
       :timer.sleep(100)
       assert called(AWS.Logs.create_log_group(:_, %{logGroupName: "testLogGroup"}))
-      assert called(AWS.Logs.create_log_stream(:_, %{logGroupName: "testLogGroup", logStreamName: log_stream_name}))
-      assert called(AWS.Logs.put_log_events(:_, %{logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}], logGroupName: "testLogGroup", logStreamName: log_stream_name, sequenceToken: :_}))
+
+      assert called(
+               AWS.Logs.create_log_stream(:_, %{
+                 logGroupName: "testLogGroup",
+                 logStreamName: log_stream_name
+               })
+             )
+
+      assert called(
+               AWS.Logs.put_log_events(:_, %{
+                 logEvents: [%InputLogEvent{message: "ArithmeticError", timestamp: :_}],
+                 logGroupName: "testLogGroup",
+                 logStreamName: log_stream_name,
+                 sequenceToken: :_
+               })
+             )
     end
   end
 
@@ -49,5 +100,4 @@ defmodule LogStreamNameTest do
   def format_name(prefix, postfix) do
     "#{prefix}_LOG_STREAM_NAME_#{postfix}"
   end
-
 end

--- a/test/support/cycler.ex
+++ b/test/support/cycler.ex
@@ -8,6 +8,8 @@ defmodule CloudWatch.Cycler do
   end
 
   def next_response do
-    Agent.get_and_update(__MODULE__, fn (state) -> {Enum.at(state.responses, state.index), Map.merge(state, %{index: state.index + 1})} end)
+    Agent.get_and_update(__MODULE__, fn state ->
+      {Enum.at(state.responses, state.index), Map.merge(state, %{index: state.index + 1})}
+    end)
   end
 end


### PR DESCRIPTION
Now one can set `:metadata` and `:metadata_filter` configuration options. This will allow for instance to push only certain logs to CloudWatch based on metadata.

For instance with this configuration
```elixir
config :logger,
  backends: [{CloudWatch, :cloud}]

config :logger, :cloud,
  log_group_name: "group",
  log_stream_name: "stream",
  metadata: [:m1, :m2],
  metadata_filter: [m3: 123]
```
only log messages with metadata `:m3` set to `123` will be sent to CloudWatch. Since `:m3` is not present in the `:metadata` list its value will not be included in resulting log message.

I changed a little bit how the configuration is taken (see the updated README) allowing multiple configurations.

The code is largely inspired by https://github.com/onkel-dirtus/logger_file_backend

I also add `.formatter.exs` and formatted the code if you don't want to include the formatting change or have it in a separate PR I can remove the commit or split PRs.